### PR TITLE
スタイルの改善

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -107,10 +107,23 @@ select, button {
 
 button {
   cursor: pointer;
+  background-color: #2563eb;
+  transition: background-color 0.2s ease;
 }
 
-button:hover {
-  background-color: #333;
+button:hover:not(:disabled) {
+  background-color: #1d4ed8;
+}
+
+button:disabled {
+  background-color: #000;
+  color: #888;
+  cursor: not-allowed;
+  opacity: 0.8;
+}
+
+button:disabled:hover {
+  background-color: #000;
 }
 
 .port-select-group {
@@ -121,16 +134,18 @@ button:hover {
 
 .request-port-btn {
   white-space: nowrap;
-  background-color: #333;
 }
 
 .connect-btn {
-  background-color: #1a1a1a;
   margin-top: 0.5rem;
 }
 
 .connect-btn.connected {
-  background-color: #2c5282;
+  background-color: #dc2626;
+}
+
+.connect-btn.connected:hover:not(:disabled) {
+  background-color: #b91c1c;
 }
 
 select {

--- a/src/index.css
+++ b/src/index.css
@@ -13,26 +13,37 @@ body {
 }
 
 .container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 2rem;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 5rem;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
 }
 
 .header {
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
+  flex-shrink: 0;
 }
 
 .main {
   display: grid;
   grid-template-columns: 2fr 1fr;
-  gap: 2rem;
+  gap: 1rem;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .monitor-display {
   background-color: #242424;
   border-radius: 8px;
   padding: 1rem;
-  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .monitor-header {
@@ -46,7 +57,7 @@ body {
   background-color: #1a1a1a;
   border-radius: 4px;
   padding: 1rem;
-  height: 400px;
+  flex: 1;
   overflow-y: auto;
 }
 
@@ -70,6 +81,7 @@ body {
   background-color: #242424;
   border-radius: 8px;
   padding: 1rem;
+  overflow-y: auto;
 }
 
 .settings-group {

--- a/src/index.css
+++ b/src/index.css
@@ -82,6 +82,7 @@ body {
   border-radius: 8px;
   padding: 1rem;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .settings-group {


### PR DESCRIPTION
## 変更内容
- コンテナサイズを画面にフィットさせ、大きく映るように修正しました
- ボタンの色を改善しました
  - 押せるボタンは青背景
  - 押せないボタンは黒背景
  - Disconnectボタンは赤背景
  - 背景色のトランジション追加

## Before
![image](https://github.com/user-attachments/assets/4a686a18-b919-4f58-bf96-62d098d3aab4)

## After
![image](https://github.com/user-attachments/assets/d6194eb5-b2ec-4652-a5ac-d32aaf73e4cb)
